### PR TITLE
Use h2 in view

### DIFF
--- a/views/templates/hook/ps_featuredproducts.tpl
+++ b/views/templates/hook/ps_featuredproducts.tpl
@@ -24,7 +24,7 @@
 *}
 
 <section>
-  <h1>{l s='Our Products' d='Modules.Featuredproducts.Shop'}</h1>
+  <h2>{l s='Our Products' d='Modules.Featuredproducts.Shop'}</h2>
   <div class="products">
     {foreach from=$products item="product"}
       {include file="catalog/_partials/miniatures/product.tpl" product=$product}


### PR DESCRIPTION
I clearly think it's better and common to use an h2 rather than an h1. For w3c validator and also often, h1 is not "our products" or "best products", it's commonly a sentence optimized for SEO or other.