### PR TITLE
Display categories using "categories" type in admin form

### DIFF
--- a/ps_featuredproducts.php
+++ b/ps_featuredproducts.php
@@ -175,11 +175,13 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
                         'desc' => $this->trans('Set the number of products that you would like to display on homepage (default: 8).', array(), 'Modules.Featuredproducts.Admin'),
                     ),
                     array(
-                        'type' => 'text',
+                        'type' => 'categories',
+                        'tree' => [
+                          'id' => 'home_featured_category',
+                          'selected_categories' => [ Configuration::get('HOME_FEATURED_CAT'), ],
+                        ],
                         'label' => $this->trans('Category from which to pick products to be displayed', array(), 'Modules.Featuredproducts.Admin'),
                         'name' => 'HOME_FEATURED_CAT',
-                        'class' => 'fixed-width-xs',
-                        'desc' => $this->trans('Choose the category ID of the products that you would like to display on homepage (default: 2 for "Home").', array(), 'Modules.Featuredproducts.Admin'),
                     ),
                     array(
                         'type' => 'switch',


### PR DESCRIPTION
```
Typing category id manually is very inconvenient. One has to navigate to
list of categories, remember/copy it, then set in ps_featuredproducts.

Use type "categories" which is exactly for this purpose - selecting
category - but displaying user-friendly tree.

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Display categories using "categories" type in admin form
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  | Change category using new tree panel. Go to home page and make sure it works.

Before:
![before](https://user-images.githubusercontent.com/452972/85952269-40049180-b968-11ea-8481-4a9975ddd9de.png)

After:
![after](https://user-images.githubusercontent.com/452972/85952270-4266eb80-b968-11ea-83ed-784923832191.png)