### PR TITLE
Invalid add_to_cart_url & actionProductSave hook into dev branch

### DIFF
--- a/ps_featuredproducts.php
+++ b/ps_featuredproducts.php
@@ -80,7 +80,6 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
             && $this->registerHook('displayOrderConfirmation2')
             && $this->registerHook('displayCrossSellingShoppingCart')
             && $this->registerHook('actionAdminGroupsControllerSaveAfter')
-            && $this->registerHook('actionAuthentication')
             && $this->registerHook('actionProductSave')
         ;
     }
@@ -117,11 +116,6 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
         $this->_clearCache('*');
     }
     
-    public function hookActionAuthentication($params)
-    {
-        $this->_clearCache('*');
-    }
-
     public function hookActionProductSave($params)
     {
         $this->_clearCache('*');
@@ -279,6 +273,15 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
         return false;
     }
 
+    protected function getCacheId($name = null)
+    { 
+        $cacheId = parent::getCacheId($name); 
+        if(isset($this->context->customer->id)){
+            $cacheId .= '|'.$this->context->customer->id;
+        } 
+        return $cacheId;
+    }
+    
     protected function getProducts()
     {
         $category = new Category((int) Configuration::get('HOME_FEATURED_CAT'));

--- a/ps_featuredproducts.php
+++ b/ps_featuredproducts.php
@@ -80,6 +80,8 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
             && $this->registerHook('displayOrderConfirmation2')
             && $this->registerHook('displayCrossSellingShoppingCart')
             && $this->registerHook('actionAdminGroupsControllerSaveAfter')
+            && $this->registerHook('actionAuthentication')
+            && $this->registerHook('actionProductSave')
         ;
     }
 
@@ -111,6 +113,16 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
     }
 
     public function hookActionAdminGroupsControllerSaveAfter($params)
+    {
+        $this->_clearCache('*');
+    }
+    
+    public function hookActionAuthentication($params)
+    {
+        $this->_clearCache('*');
+    }
+
+    public function hookActionProductSave($params)
     {
         $this->_clearCache('*');
     }

--- a/ps_featuredproducts.php
+++ b/ps_featuredproducts.php
@@ -277,7 +277,7 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
     { 
         $cacheId = parent::getCacheId($name); 
         if(isset($this->context->customer->id)){
-            $cacheId .= '|'.$this->context->customer->id;
+            $cacheId .= '|'.(int)$this->context->customer->id;
         } 
         return $cacheId;
     }

--- a/ps_featuredproducts.php
+++ b/ps_featuredproducts.php
@@ -115,7 +115,7 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
     {
         $this->_clearCache('*');
     }
-    
+
     public function hookActionProductSave($params)
     {
         $this->_clearCache('*');
@@ -274,14 +274,15 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
     }
 
     protected function getCacheId($name = null)
-    { 
-        $cacheId = parent::getCacheId($name); 
-        if(isset($this->context->customer->id)){
-            $cacheId .= '|'.(int)$this->context->customer->id;
-        } 
+    {
+        $cacheId = parent::getCacheId($name);
+        if (isset($this->context->customer->id)) {
+            $cacheId .= '|' . (int) $this->context->customer->id;
+        }
+
         return $cacheId;
     }
-    
+
     protected function getProducts()
     {
         $category = new Category((int) Configuration::get('HOME_FEATURED_CAT'));

--- a/upgrade/upgrade-2.1.1.php
+++ b/upgrade/upgrade-2.1.1.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+/**
+ * @param Module $module
+ *
+ * @return bool
+ */
+function upgrade_module_2_1_1($module)
+{
+    $module->registerHook('actionProductSave');
+
+    return true;
+}


### PR DESCRIPTION
PR #32 but into dev branch

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | solves two problems with cache (described below)
| Type?         | bug fix
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Simple code to read ;-)

2 problems:
* add_to_cart_url has invalid token after login to different account.
* in prestashop 1.7.7.0 we need actionProductSave hook to recalculate featured products when something changes. (after changing visibility of product I had no changes in featured products section - I needed to clear cache)
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
