### PR TITLE
Fix cache key id

### DIFF
--- a/ps_featuredproducts.php
+++ b/ps_featuredproducts.php
@@ -323,13 +323,7 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
     protected function getCacheId($name = null)
     {
         $cacheId = parent::getCacheId($name);
-        if (empty($this->context->customer)) {
-            $defaultTaxRule = Configuration::get('DEFAULT_TAX_RULE');
-            $taxAddressType = Configuration::get('PS_TAX_ADDRESS_TYPE');
-            $address = Address::initialize($this->context->cart->$taxAddressType, true);
-            $taxManager = TaxManagerFactory::getManager($address, $defaultTaxRule);
-            $cacheId .= '|' . $taxManager->getTaxCalculator()->getTotalRate();
-        } else {
+        if (!empty($this->context->customer->id)) {
             $cacheId .= '|' . $this->context->customer->id;
         }
 

--- a/ps_featuredproducts.php
+++ b/ps_featuredproducts.php
@@ -319,4 +319,20 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
 
         return $products_for_template;
     }
+    
+    protected function getCacheId($name = null)
+    {
+        $cacheId = parent::getCacheId($name);
+        if (empty($this->context->customer)) {
+            $defaultTaxRule = Configuration::get('DEFAULT_TAX_RULE');
+            $taxAddressType = Configuration::get('PS_TAX_ADDRESS_TYPE');
+            $address = Address::initialize($this->context->cart->$taxAddressType, true);
+            $taxManager = TaxManagerFactory::getManager($address, $defaultTaxRule);
+            $cacheId .= '|' . $taxManager->getTaxCalculator()->getTotalRate();
+        } else {
+            $cacheId .= '|' . $this->context->customer->id;
+        }
+
+        return $cacheId;
+    }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The current cache strategy "getCacheId()" does not use all the variables that affect the price, proving that incorrect values are shown in the price to many customers. PrestaShop/Prestashop#17111
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#17111
| How to test?  | https://github.com/PrestaShop/ps_featuredproducts/pull/34#issuecomment-912696467
