### PR TITLE
Do not autohook on displayCrossSellingShoppingCart

### DIFF
--- a/ps_featuredproducts.php
+++ b/ps_featuredproducts.php
@@ -72,7 +72,6 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
             && $this->registerHook('actionProductDelete')
             && $this->registerHook('displayHome')
             && $this->registerHook('displayOrderConfirmation2')
-            && $this->registerHook('displayCrossSellingShoppingCart')
             && $this->registerHook('actionCategoryUpdate')
             && $this->registerHook('actionAdminGroupsControllerSaveAfter')
         ;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Featured product module shouldn't be hooked on displayCrossSellingShoppingCart by default and shouldn't be displayed by default in the cart. - https://github.com/PrestaShop/PrestaShop/pull/26663#issuecomment-979038447
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | None
| How to test?  | -

Related PR: https://github.com/PrestaShop/PrestaShop/pull/27022
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
