### PR TITLE
Add OnlyAvailable and PopularFirst options for featured products

### DIFF
--- a/ps_featuredproducts.php
+++ b/ps_featuredproducts.php
@@ -394,9 +394,6 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
 
         $sql .= ' LIMIT ' . (int) $nProducts;
 
-        // print($sql);
-        // exit;
-
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql, true, false);
 
         if (!$result) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Adds an ability to change order of the featured products and filter out products that are not available for ordering. Right now if a product is unavailable it can still be visible inside featured products which can be kinda pointless. This PR will also introduce a way to change the order of displayed products to display products which have been ordered the most.
| Type?         | improvement
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Change module settings, Verify homepage


<img width="781" alt="image" src="https://user-images.githubusercontent.com/6031161/234281263-4f0cc16b-d718-4797-ad0a-c95cff6b8ecf.png">
