### PR TITLE
Use `ProductListingPresenter` instead of `ProductPresenter`

### DIFF
--- a/ps_featuredproducts.php
+++ b/ps_featuredproducts.php
@@ -28,6 +28,9 @@ if (!defined('_PS_VERSION_')) {
 }
 
 use PrestaShop\PrestaShop\Adapter\Category\CategoryProductSearchProvider;
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
+use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
+use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchContext;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
@@ -299,7 +302,27 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
 
         $presenterFactory = new ProductPresenterFactory($this->context);
         $presentationSettings = $presenterFactory->getPresentationSettings();
-        $presenter = $presenterFactory->getPresenter();
+        if (version_compare(_PS_VERSION_, '1.7.5', '>=')) {
+            $presenter = new \PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter(
+                new ImageRetriever(
+                    $this->context->link
+                ),
+                $this->context->link,
+                new PriceFormatter(),
+                new ProductColorsRetriever(),
+                $this->context->getTranslator()
+            );
+        } else {
+            $presenter = new \PrestaShop\PrestaShop\Core\Product\ProductListingPresenter(
+                new ImageRetriever(
+                    $this->context->link
+                ),
+                $this->context->link,
+                new PriceFormatter(),
+                new ProductColorsRetriever(),
+                $this->context->getTranslator()
+            );
+        }
 
         $products_for_template = [];
 

--- a/tests/phpstan/phpstan-1.7.1.2.neon
+++ b/tests/phpstan/phpstan-1.7.1.2.neon
@@ -5,3 +5,5 @@ parameters:
   ignoreErrors:
     - '#Call to method assign\(\) on an unknown class Smarty_Data#'
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given#'
+    - '#Call to method present\(\) on an unknown class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter.#'
+    - '#Instantiated class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter not found.#'

--- a/tests/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/phpstan/phpstan-1.7.2.5.neon
@@ -5,3 +5,5 @@ parameters:
   ignoreErrors:
     - '#Call to method assign\(\) on an unknown class Smarty_Data#'
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given#'
+    - '#Call to method present\(\) on an unknown class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter.#'
+    - '#Instantiated class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter not found.#'

--- a/tests/phpstan/phpstan-1.7.3.4.neon
+++ b/tests/phpstan/phpstan-1.7.3.4.neon
@@ -5,3 +5,5 @@ parameters:
   ignoreErrors:
     - '#Call to method assign\(\) on an unknown class Smarty_Data#'
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given#'
+    - '#Call to method present\(\) on an unknown class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter.#'
+    - '#Instantiated class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter not found.#'

--- a/tests/phpstan/phpstan-1.7.4.4.neon
+++ b/tests/phpstan/phpstan-1.7.4.4.neon
@@ -4,3 +4,5 @@ includes:
 parameters:
   ignoreErrors:
     - '#Parameter \#1 \$idCategory of class Category constructor expects null, int given#'
+    - '#Call to method present\(\) on an unknown class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter.#'
+    - '#Instantiated class PrestaShop\\PrestaShop\\Adapter\\Presenter\\Product\\ProductListingPresenter not found.#'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Use `ProductListingPresenter` instead of `ProductPresenter` like other native modules: `ps_bestsellers`, `ps_crossselling`, `ps_newproducts` and `ps_specials`.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/33979.
| How to test?  | Check if the module still lists products on homepage in front office. Check if hook `actionProductListingPresenter` is launched when visiting the homepage.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
