### PR TITLE
Remove caching system and bump version to 3.0.0

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_featuredproducts</name>
     <displayName><![CDATA[Featured products]]></displayName>
-    <version><![CDATA[2.1.6]]></version>
+    <version><![CDATA[3.0.0]]></version>
     <description><![CDATA[Displays featured products in the central column of your homepage.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/ps_featuredproducts.php
+++ b/ps_featuredproducts.php
@@ -44,7 +44,7 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
     {
         $this->name = 'ps_featuredproducts';
         $this->author = 'PrestaShop';
-        $this->version = '2.1.6';
+        $this->version = '3.0.0';
         $this->need_instance = 0;
 
         $this->ps_versions_compliancy = [
@@ -63,58 +63,14 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
 
     public function install()
     {
-        $this->_clearCache('*');
-
         Configuration::updateValue('HOME_FEATURED_NBR', 8);
         Configuration::updateValue('HOME_FEATURED_CAT', (int) Context::getContext()->shop->getCategory());
         Configuration::updateValue('HOME_FEATURED_RANDOMIZE', false);
 
         return parent::install()
-            && $this->registerHook('actionProductAdd')
-            && $this->registerHook('actionProductUpdate')
-            && $this->registerHook('actionProductDelete')
             && $this->registerHook('displayHome')
             && $this->registerHook('displayOrderConfirmation2')
-            && $this->registerHook('actionCategoryUpdate')
-            && $this->registerHook('actionAdminGroupsControllerSaveAfter')
         ;
-    }
-
-    public function uninstall()
-    {
-        $this->_clearCache('*');
-
-        return parent::uninstall();
-    }
-
-    public function hookActionProductAdd($params)
-    {
-        $this->_clearCache('*');
-    }
-
-    public function hookActionProductUpdate($params)
-    {
-        $this->_clearCache('*');
-    }
-
-    public function hookActionProductDelete($params)
-    {
-        $this->_clearCache('*');
-    }
-
-    public function hookActionCategoryUpdate($params)
-    {
-        $this->_clearCache('*');
-    }
-
-    public function hookActionAdminGroupsControllerSaveAfter($params)
-    {
-        $this->_clearCache('*');
-    }
-
-    public function _clearCache($template, $cache_id = null, $compile_id = null)
-    {
-        parent::_clearCache($this->templateFile);
     }
 
     public function getContent()
@@ -143,8 +99,6 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
                 Configuration::updateValue('HOME_FEATURED_NBR', (int) $nbr);
                 Configuration::updateValue('HOME_FEATURED_CAT', (int) $cat);
                 Configuration::updateValue('HOME_FEATURED_RANDOMIZE', (bool) $rand);
-
-                $this->_clearCache('*');
 
                 $output = $this->displayConfirmation($this->trans('The settings have been updated.', [], 'Admin.Notifications.Success'));
             }
@@ -237,17 +191,15 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
 
     public function renderWidget($hookName = null, array $configuration = [])
     {
-        if (!$this->isCached($this->templateFile, $this->getCacheId('ps_featuredproducts'))) {
-            $variables = $this->getWidgetVariables($hookName, $configuration);
+        $variables = $this->getWidgetVariables($hookName, $configuration);
 
-            if (empty($variables)) {
-                return false;
-            }
-
-            $this->smarty->assign($variables);
+        if (empty($variables)) {
+            return false;
         }
 
-        return $this->fetch($this->templateFile, $this->getCacheId('ps_featuredproducts'));
+        $this->smarty->assign($variables);
+
+        return $this->fetch($this->templateFile);
     }
 
     public function getWidgetVariables($hookName = null, array $configuration = [])
@@ -342,15 +294,5 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
         }
 
         return $products_for_template;
-    }
-
-    protected function getCacheId($name = null)
-    {
-        $cacheId = parent::getCacheId($name);
-        if (!empty($this->context->customer->id)) {
-            $cacheId .= '|' . $this->context->customer->id;
-        }
-
-        return $cacheId;
     }
 }

--- a/upgrade/upgrade-3.0.0.php
+++ b/upgrade/upgrade-3.0.0.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_3_0_0($module)
+{
+    $module->unregisterHook('actionProductAdd');
+    $module->unregisterHook('actionProductUpdate');
+    $module->unregisterHook('actionProductDelete');
+    $module->unregisterHook('actionCategoryUpdate');
+    $module->unregisterHook('actionAdminGroupsControllerSaveAfter');
+
+    return true;
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Removes caching system from this module to fix all issues with outdated data being displayed on homepage. Once you display anything more than a price on the product miniature, the data is outdated. Availability displays yesterdays date or wrong message. There is only a negligible slowdown, it's only 8 products, we load much more in a category, where there is no caching.
| Type?             | refacto
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | 
| Sponsor company   | TRENDO s.r.o.